### PR TITLE
iOS9 fix, monochrome ascii, boulder symbol, notes

### DIFF
--- a/Classes/AsciiTileSet.m
+++ b/Classes/AsciiTileSet.m
@@ -59,7 +59,31 @@ static float _colorTable[][4] = {
 		UIColor *brightMagentaColor = [[UIColor alloc] initWithRed:0.2f green:0 blue:0.2f alpha:1];
 		UIColor *brightCyanColor = [[UIColor alloc] initWithRed:0 green:1 blue:1 alpha:1];
         UIColor *blackColor = [[UIColor alloc] initWithRed:0.2f green:0.2f blue:0.2f alpha:1];
-		colorTable = [[NSArray alloc] initWithObjects:
+        
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        //iNethack2: monochrome ascii
+        NSString *theTileset = [defaults objectForKey:@"tileset"];
+        if ([theTileset isEqualToString:@"asciimono"]) {
+            colorTable = [[NSArray alloc] initWithObjects:
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor], // NO_COLOR
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          [UIColor lightGrayColor],
+                          nil];
+        } else {
+            colorTable = [[NSArray alloc] initWithObjects:
 					  blackColor, //[UIColor blackColor], //iNethack2: use dark grey so you can see black monsters/items
 					  [UIColor redColor],
 					  [UIColor greenColor],
@@ -77,6 +101,7 @@ static float _colorTable[][4] = {
 					  brightCyanColor,
 					  [UIColor whiteColor],
 					  nil];
+        }
 		[brightGreenColor release];
 		[brightBlueColor release];
 		[brightMagentaColor release];

--- a/Classes/MainView.m
+++ b/Classes/MainView.m
@@ -77,7 +77,7 @@
 	if (!tilesetName) {
 		tilesetName = @"chozo32b";
 	}
-	if ([tilesetName isEqualToString:@"ascii"]) {
+	if ([tilesetName isEqualToString:@"ascii"] || [tilesetName isEqualToString:@"asciimono"]) {
 		asciiTileset = YES;
 		tileSet = [[AsciiTileSet alloc] initWithTileSize:tilesetTileSize];
 	} else {

--- a/Classes/TextDisplayViewController.m
+++ b/Classes/TextDisplayViewController.m
@@ -79,10 +79,12 @@
 		self.view = webView;
 		[webView release];
 	} else {
-		textView = [[UITextView alloc] initWithFrame:self.view.frame];
+        textView = [[UITextView alloc] initWithFrame:self.view.frame];
 		textView.backgroundColor = [UIColor blackColor];
 		textView.textColor = [UIColor whiteColor];
 		textView.editable = NO;
+        textView.scrollEnabled = NO;    //iOS9 fix: disable then enable scrolling so initial scrolling works
+        textView.scrollEnabled = YES;   //...
 		self.view = textView;
 		[textView release];
 	}

--- a/Info.plist
+++ b/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.futureshocksoftware.inethack2</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Info.plist
+++ b/Info.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>25</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMainNibFile</key>

--- a/Settings.bundle/Root.plist
+++ b/Settings.bundle/Root.plist
@@ -119,6 +119,7 @@
 				<string>NeXTSTEP</string>
 				<string>Tiles32</string>
 				<string>ASCII</string>
+				<string>ASCII (monochrome)</string>
 			</array>
 			<key>Values</key>
 			<array>
@@ -132,7 +133,18 @@
 				<string>nextstep</string>
 				<string>tiles32</string>
 				<string>ascii</string>
+				<string>asciimono</string>
 			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Boulder Symbol</string>
+			<key>Key</key>
+			<string>boulderSym</string>
+			<key>DefaultValue</key>
+			<string>`</string>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/iNetHack.xcodeproj/project.pbxproj
+++ b/iNetHack.xcodeproj/project.pbxproj
@@ -1359,7 +1359,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0700;
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
 						DevelopmentTeam = JV43X8XJFX;
@@ -1724,6 +1724,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = iNetHack_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.futureshocksoftware.inethack2;
 				PRODUCT_NAME = iNetHack2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1740,6 +1741,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = iNetHack_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.futureshocksoftware.inethack2;
 				PRODUCT_NAME = iNetHack2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1773,6 +1775,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = iNetHack_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.futureshocksoftware.inethack2;
 				PRODUCT_NAME = iNetHack2;
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1784,6 +1787,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;

--- a/manual.html
+++ b/manual.html
@@ -43,7 +43,13 @@
 		<ul>
 			<li>You can <b>swipe</b> in single-item menus (throw and drop) to specify amounts.</li>
 		</ul>
-		<h2>More Information</h2>
+
+        <h2>Settings</h2>
+        <ul>
+            <li>You can change your <b>character name</b>, <b>tileset</b>, <b>autopickup settings</b> and many other things by exiting the app, launching the iOS Settings app, scrolling to iNethack2 in the app list and selecting it.</li>
+        </ul>
+
+        <h2>More Information</h2>
 		<li>See the <a href="http://www.nethack.org/v343/Guidebook.html">NetHack Guidebook</a> for in-depth information</li>
 		<li><a href="http://www.melankolia.net/nethack/nethack.guide.html">Beginner's Guide</a>
 	</body>

--- a/nethack/win/iphone/winiphone.m
+++ b/nethack/win/iphone/winiphone.m
@@ -49,6 +49,7 @@
 #define kOptionUsername (@"username")
 #define kOptionAutopickup (@"autopickup")
 #define kOptionPickupTypes (@"pickupTypes")
+#define kOptionBoulderSym (@"boulderSym")
 #define kOptionWizard (@"wizard")
 #define kOptionAutokick (@"autokick")
 #define kOptionTime (@"time")
@@ -136,6 +137,7 @@ genl_preference_update,
 	[defaults registerDefaults:[NSDictionary dictionaryWithObjectsAndKeys:
 								@"YES", kOptionAutopickup,
 								@"$\"=/!?+", kOptionPickupTypes,
+                                @"`", kOptionBoulderSym,
 								@"YES", kOptionAutokick,
 								@"YES", kOptionShowExp,
 								@"YES", kOptionTime,
@@ -537,7 +539,19 @@ void iphone_init_options() {
 	flags.verbose = TRUE;
 	flags.toptenwin = TRUE;
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-	flags.pickup = [defaults boolForKey:kOptionAutopickup];
+    //iNethack2: custom boulder symbol
+    NSString *boulderSym = [defaults objectForKey:kOptionBoulderSym];
+    if (boulderSym==NULL)
+        boulderSym=@"`";
+    const char *bould = [boulderSym UTF8String];
+    boulderSym = [boulderSym substringToIndex:1];
+    //Update user preference to ensure it's only 1 character long
+    if ([[NSUserDefaults standardUserDefaults] stringForKey:@"boulderSym"]) {
+        [[NSUserDefaults standardUserDefaults] setObject:boulderSym forKey:@"boulderSym"];
+    }
+    iflags.bouldersym = (uchar) bould[0];
+    
+    flags.pickup = [defaults boolForKey:kOptionAutopickup];
 	NSString *pickupTypes = [defaults objectForKey:kOptionPickupTypes];
 	if (flags.pickup && pickupTypes) {
 		NSMutableString *tmp = [NSMutableString string];
@@ -550,7 +564,7 @@ void iphone_init_options() {
 		[tmp getCString:flags.pickup_types maxLength:MAXOCLASSES encoding:NSASCIIStringEncoding];
 	}
 #if TARGET_IPHONE_SIMULATOR
-	wizard = NO; //akolade YES for sim usually..
+	wizard = NO; //iNethack2 YES for sim usually..
 #else
 	wizard = [defaults boolForKey:kOptionWizard];
 #endif


### PR DESCRIPTION
- Fix for log scrolling bug caused by iOS9
- Added "ASCII monochrome" tileset, essentially just making the colour table all light grey
- Added configurable boulder symbol to settings so if you are playing with ASCII you can change it from the default ` symbol (for example a zero "0")
- Added some additional instructions on the Manual page to address common questions about settings
