### PR TITLE
Fix a few problems with logging system in Hearse

### DIFF
--- a/Classes/Hearse.h
+++ b/Classes/Hearse.h
@@ -95,6 +95,7 @@
 - (void) alertUserWithError:(NSError *)error;
 - (void) logHearseMessage:(NSString *)message;
 - (void) logMessage:(NSString *)message;
+- (void) logMessage:(NSString *)message format:(va_list)format;
 - (void) logFormat:(NSString *)message, ...;
 
 @end

--- a/Classes/Hearse.m
+++ b/Classes/Hearse.m
@@ -475,9 +475,18 @@ static NSString *const hearseCommandDownload = @"download";
 	[self logMessage:msg];
 }
 
+- (void) logMessage:(NSString *)message format:(va_list)format
+{
+	if (message) {
+		NSString *s = [[NSString alloc] initWithFormat:message arguments:format];
+		[self logMessage:s];
+		[s release];
+	}
+}
+
 - (void) logMessage:(NSString *)message {
 	if (message) {
-		NSLogv(message, NULL);
+		NSLog(@"%@", message);
 		[logger logString:message];
 	}
 }
@@ -485,9 +494,8 @@ static NSString *const hearseCommandDownload = @"download";
 - (void) logFormat:(NSString *)message, ... {
 	va_list vlist;
 	va_start(vlist, message);
-	NSString *s = [[NSString alloc] initWithFormat:message arguments:vlist];
-	[self logMessage:s];
-	[s release];
+	[self logMessage:message format:vlist];
+	va_end(vlist);
 }
 
 - (void) dealloc {

--- a/Classes/MainViewController.h
+++ b/Classes/MainViewController.h
@@ -91,6 +91,7 @@
 
 + (MainViewController *) instance;
 + (void) message:(NSString *)format, ...;
++ (void) message:(NSString *)message format:(va_list)arg_list;
 
 - (void) launchNetHack;
 - (void) mainNethackLoop:(id)arg;

--- a/Classes/MainViewController.m
+++ b/Classes/MainViewController.m
@@ -58,13 +58,22 @@ static MainViewController *instance;
 	return instance;
 }
 
++ (void)messageWithoutFormat:(NSString*)msg {
+	[[[self instance] messageWindow] putString:[msg cStringUsingEncoding:NSASCIIStringEncoding]];
+}
+
++ (void) message:(NSString *)message format:(va_list)arg_list {
+	NSString *msg = [[NSString alloc] initWithFormat:message arguments:arg_list];
+	[self messageWithoutFormat:msg];
+	[msg release];
+}
+
+
 + (void) message:(NSString *)format, ... {
 	va_list arg_list;
 	va_start(arg_list, format);
-	NSString *msg = [[NSString alloc] initWithFormat:format arguments:arg_list];
+	[self message:format format:arg_list];
 	va_end(arg_list);
-	[[[self instance] messageWindow] putString:[msg cStringUsingEncoding:NSASCIIStringEncoding]];
-	[msg release];
 }
 
 - (void) awakeFromNib {


### PR DESCRIPTION
`-logFormat:, ...` didn't have a call to `va_end`.
Xcode 7 was complaining about having a null pointer being passed to `NSLogv`; use `NSLog(@"%@", message)` instead.
Add `-logMessage:format:` for future Swift compatibility.
