### PR TITLE
Amount textbox, bugfix..

### DIFF
--- a/Classes/ItemAmountView.xib
+++ b/Classes/ItemAmountView.xib
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="5000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ItemAmountViewController">
             <connections>
                 <outlet property="amountSlider" destination="8" id="10"/>
+                <outlet property="amountTextField" destination="cGl-fO-w2d" id="PDg-zD-RAh"/>
                 <outlet property="amountTextLabel" destination="7" id="11"/>
                 <outlet property="dropButton" destination="15" id="16"/>
                 <outlet property="imageView" destination="4" id="14"/>
@@ -48,8 +49,13 @@
                     <color key="textColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cGl-fO-w2d" userLabel="Amount Text Field">
+                    <rect key="frame" x="127" y="165" width="69" height="30"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
                 <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="15">
-                    <rect key="frame" x="124" y="137" width="72" height="36"/>
+                    <rect key="frame" x="127" y="250" width="72" height="36"/>
                     <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                     <state key="normal" title="OK">
                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -61,9 +67,4 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
         </view>
     </objects>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/Classes/ItemAmountViewController.h
+++ b/Classes/ItemAmountViewController.h
@@ -32,6 +32,7 @@
 	IBOutlet UILabel *amountTextLabel;
 	IBOutlet UISlider *amountSlider;
 	IBOutlet UIButton *dropButton;
+    IBOutlet UITextField *amountTextField; //akolade
 	
 	Window *menuWindow;
 	BOOL targetsSet;

--- a/Classes/ItemAmountViewController.h
+++ b/Classes/ItemAmountViewController.h
@@ -32,7 +32,7 @@
 	IBOutlet UILabel *amountTextLabel;
 	IBOutlet UISlider *amountSlider;
 	IBOutlet UIButton *dropButton;
-    IBOutlet UITextField *amountTextField; //akolade
+    IBOutlet UITextField *amountTextField; //iNethack2: amount text box
 	
 	Window *menuWindow;
 	BOOL targetsSet;

--- a/Classes/ItemAmountViewController.m
+++ b/Classes/ItemAmountViewController.m
@@ -65,7 +65,7 @@ extern short glyph2tile[];
 	menuWindow.nethackMenuItem.amount = v;
 }
 
-//akolade
+//iNethack2: amount text box value changed
 - (void) textValueHasChanged:(id)sender {
     UITextField *textfield = (UITextField *) sender;
     //UISlider *slider = (UISlider *) sender;
@@ -102,7 +102,7 @@ extern short glyph2tile[];
 		[amountSlider addTarget:self action:@selector(sliderValueHasChanged:) forControlEvents:UIControlEventValueChanged];
 		[dropButton addTarget:self action:@selector(finishPickOne:) forControlEvents:UIControlEventTouchUpInside];
         
-        //akolade
+        //iNethack2: amount text box setup
         [amountTextField addTarget:self action:@selector(textValueHasChanged:) forControlEvents:
          UIControlEventEditingChanged];
         

--- a/Classes/ItemAmountViewController.m
+++ b/Classes/ItemAmountViewController.m
@@ -58,7 +58,27 @@ extern short glyph2tile[];
 	UISlider *slider = (UISlider *) sender;
 	int v = round(slider.value);
 	amountTextLabel.text = [NSString stringWithFormat:@"%d", v];
+    
+    int textv = [amountTextField.text intValue];
+    if (textv!=v)
+        amountTextField.text = [NSString stringWithFormat:@"%d", v];
 	menuWindow.nethackMenuItem.amount = v;
+}
+
+//akolade
+- (void) textValueHasChanged:(id)sender {
+    UITextField *textfield = (UITextField *) sender;
+    //UISlider *slider = (UISlider *) sender;
+    //int v = round(slider.value);
+
+    int v = [textfield.text intValue];
+    int maxminv = min(v, amountSlider.maximumValue);
+    maxminv = max(maxminv, amountSlider.minimumValue);
+    if (amountSlider.value != maxminv)
+        amountSlider.value = maxminv;
+    amountTextLabel.text = [NSString stringWithFormat:@"%d", maxminv];
+    menuWindow.nethackMenuItem.amount = maxminv;
+    
 }
 
 - (void) finishPickOne:(id)sender {
@@ -74,12 +94,18 @@ extern short glyph2tile[];
 
 - (void)viewWillAppear:(BOOL)animated {
 	amountSlider.continuous = YES;
+
 	if (!targetsSet) {
 		// things like this should be in awakeFromNib
 		// but when called the outlets don't seem to be initialized
 		// so we have to do that here
 		[amountSlider addTarget:self action:@selector(sliderValueHasChanged:) forControlEvents:UIControlEventValueChanged];
 		[dropButton addTarget:self action:@selector(finishPickOne:) forControlEvents:UIControlEventTouchUpInside];
+        
+        //akolade
+        [amountTextField addTarget:self action:@selector(textValueHasChanged:) forControlEvents:
+         UIControlEventEditingChanged];
+        
 		targetsSet = YES;
 	}
 	if (menuWindow.nethackMenuItem.glyph != NO_GLYPH && menuWindow.nethackMenuItem.glyph != kNoGlyph) {
@@ -100,6 +126,10 @@ extern short glyph2tile[];
 	amountSlider.minimumValue = 0;
 	amountSlider.maximumValue = amount;
 	amountSlider.value = amount;
+    
+
+    [amountTextField setKeyboardType:UIKeyboardTypeDecimalPad];
+    amountTextField.text = [NSString stringWithFormat:@"%d",amount];
 }
 
 - (void)dealloc {

--- a/Classes/MenuViewController.m
+++ b/Classes/MenuViewController.m
@@ -49,12 +49,14 @@
     tv.separatorStyle = UITableViewCellSeparatorStyleNone; // iNethack2: prevent line separator
 
     //iNethack2: fix for not scrolling all the way to bottom for iphone5+
-    //iNethack2: UPDATE: now in iOS9, this fix actually isn't needed and it just causes trouble. So commenting out!
-    /*
-    long bottom;
-    bottom= (self.view.frame.size.height + self.view.frame.origin.y) - [MenuViewController screenSize].height;
-    [self.tableView setContentInset:UIEdgeInsetsMake(0, 0, bottom, 0)];
-     */
+    //iNethack2: only needed for iOS8 and less..
+    if (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_8_3) {
+        long bottom;
+        bottom= (self.view.frame.size.height + self.view.frame.origin.y) - [MenuViewController screenSize].height;
+        [self.tableView setContentInset:UIEdgeInsetsMake(0, 0, bottom, 0)];
+    }
+    
+    
 }
 
 #pragma mark UITableView delegate

--- a/Info.plist
+++ b/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>2.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>26</string>
+	<string>27</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.adventure-games</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Info.plist
+++ b/Info.plist
@@ -43,5 +43,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
-New feature: Added a text box input to the Amount selection screen, which works in tandem with the slider. For times when you have a lot of items (like gold) it could be tricky to accurately select the right amount with the slider, so this let's you type it into the box as an alternative
-Fixed an issue in iOS8 caused by a fix for iOS9. The role selection screen wasn't able to scroll to the bottom
-Turned on the file-sharing setting in the app settings. Some players like the ability to copy off their save files. This was enabled previously but recent XCode change this to default off
